### PR TITLE
Allow host port to be overriden using env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redis Vagrant box
 
-This is a build for a [Vagrant](https://www.vagrantup.com/) box. Intended use is when Redis is required but you do not wish to install it locally. Instead you can grab this build and create a Vagrant instance instead.
+This is a build for a [Vagrant](https://www.vagrantup.com/) box whose base is [Ubuntu Server 14.04 LTS](https://atlas.hashicorp.com/ubuntu/boxes/trusty64) with just an install of [Redis](http://redis.io/). Intended use is when Redis is required but you do not wish to install it locally. Instead you can grab this build and create a Vagrant instance instead.
 
 ## Requirements
 
@@ -11,17 +11,24 @@ You will need to have installed [VirtualBox](https://www.virtualbox.org/) and Va
 Clone the repository, copying the project into a working directory
 
 ```bash
-git clone https://github.com/Cruikshanks/redis-vagrant-box.git
-cd redis-vagrant-box
+git clone https://github.com/Cruikshanks/redis-box.git && cd redis-box
 ```
 
-To create the vagrant box, provision it and start the Redis services simply run:
+To create the vagrant box, provision it and start the Redis services simply run
 
 ```bash
 vagrant up
 ```
 
 This will take a while the first time it runs, as it needs to build the virtual machine from scratch. Once done it will then start it up in the background.
+
+### Host port
+
+By default port 6379 will be bound from the host to the guest to enable access to MongoDB from the host. If you wish to change this set an environment variable (`REDISBOX_HOST_PORT`) to the port you wish to use. The easiest way to do this is when calling `vagrant up` itself.
+
+```bash
+REDISBOX_HOST_PORT=6380 vagrant up
+```
 
 ### Caching
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,11 @@
 # rubocop:disable StringLiterals
 # rubocop:disable LineLength
 
+# Confirm the host port to bind to. The default of 6379 is used if the env var
+# is not set, but this allows us to be flexible (for example where a port
+# conflict occurs)
+host_port = ENV["REDISBOX_HOST_PORT"] || 6379
+
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what
@@ -25,18 +30,8 @@ Vagrant.configure(2) do |config|
   end
 
   # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network "forwarded_port", guest: 6379, host: 6379
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
+  # within the machine from a port on the host machine.
+  config.vm.network "forwarded_port", guest: 6379, host: host_port
 
   # General provisioning of the box. Ensure time is set correctly and do an
   # initial apt-get update, plus install packages commonly needed by all boxes


### PR DESCRIPTION
This change updates the Vagrant file to enable the ability to specify which port should be bound on the host using an environment variable. This gives more flexibility and means a change in code is not required should you need to use a different port number.

The changes also cover updating the README to include details about this ability.
