### PR TITLE
Remove always run start section from Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,8 +43,4 @@ Vagrant.configure(2) do |config|
 
   # Specific provisioning of the box
   config.vm.provision "shell", name: "redis", path: "buildsteps/redis.sh"
-
-  config.vm.provision "shell", name: "startup", run: "always", inline: <<-SHELL
-    service redis-server restart
-  SHELL
 end

--- a/buildsteps/redis.sh
+++ b/buildsteps/redis.sh
@@ -1,3 +1,6 @@
 #!/bin/bash -x
 
 sudo apt-get -y install redis-server
+
+# Redis is automatically added to startup so the following line is not needed
+# update-rc.d redis-server defaults


### PR DESCRIPTION
On another project found that we could infact add a service to start up using update-rc.d (`update-rc.d redis-server defaults`). However upon trying it for Redis got a message back saying this had already been done.

This meant that the final section in the Vagrantfile is no longer necessary so have removed it.
